### PR TITLE
Add fan sensors

### DIFF
--- a/SensorsKit/SensorHistoryData.swift
+++ b/SensorsKit/SensorHistoryData.swift
@@ -34,12 +34,14 @@ public class SensorHistoryData: NSObject, Synchronizable
         case voltage
         case current
         case ambiantLight
+        case rpm
 
         public var description: String
         {
             switch self
             {
                 case .thermal:      return "thermal"
+                case .rpm:          return "rpm"
                 case .voltage:      return "voltage"
                 case .current:      return "current"
                 case .ambiantLight: return "ambiantLight"

--- a/SensorsKit/Sensors.swift
+++ b/SensorsKit/Sensors.swift
@@ -35,10 +35,13 @@ public class Sensors: NSObject
 
     private var shouldRun = true
     private var completion: ( () -> Void )?
+    private var regexFanRPM: NSRegularExpression
 
     @objc
     public override init()
     {
+        self.regexFanRPM = try! NSRegularExpression( pattern: "F[0-9]Ac" )
+
         super.init()
 
         DispatchQueue.global( qos: .background ).async
@@ -114,6 +117,7 @@ public class Sensors: NSObject
         let all = SMC.shared.readAllKeys()
 
         all.filter { $0.keyName.hasPrefix( "T" ) }.forEach { self.addSensorHistoryData( data: $0, kind: .thermal ) }
+        all.filter { self.regexFanRPM.firstMatch(in: $0.keyName, range: NSMakeRange(0, $0.keyName.count)) != nil }.forEach { self.addSensorHistoryData( data: $0, kind: .rpm ) }
         all.filter { $0.keyName.hasPrefix( "V" ) }.forEach { self.addSensorHistoryData( data: $0, kind: .voltage ) }
         all.filter { $0.keyName.hasPrefix( "I" ) }.forEach { self.addSensorHistoryData( data: $0, kind: .current ) }
     }


### PR DESCRIPTION
This change adds Fan RPM sensors to SensorKit used in new changed in Sensor and Hot repos.

The `SensorHistoryData` enum `Kind` now has a `.rpm` which is set for SMC sensor values who's keyName matches `F[0-0]Ac`.

This change is need in PR's to `Sensors` and `Hot`:
https://github.com/macmade/Sensors/pull/5
https://github.com/macmade/Hot/pull/98
